### PR TITLE
Feat/wrapper pyparsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,11 @@ import os
 import sys
 
 import psqlparser
-import wrapper
+import psqlwrapper
 
 if len(sys.argv) > 1:    
-    wrap = wrapper.Wrapper(sys.argv[1].encode("utf-8"), lambda x : "Helpful message", psqlparser.PsqlParser)
+    wrap = psqlwrapper.PsqlWrapper(sys.argv[1].encode("utf-8"),
+                                   lambda x : "Helpful message",
+                                   psqlparser.PsqlParser)
 else:
     print(f"{os.path.basename(sys.executable)} main.py <database name>")

--- a/main.py
+++ b/main.py
@@ -4,9 +4,9 @@ import sys
 import psqlparser
 import psqlwrapper
 
-if len(sys.argv) > 1:    
+if len(sys.argv) > 1:
     wrap = psqlwrapper.PsqlWrapper(sys.argv[1].encode("utf-8"),
                                    lambda x : "Helpful message",
-                                   psqlparser.PsqlParser)
+                                   psqlparser.PsqlParser())
 else:
     print(f"{os.path.basename(sys.executable)} main.py <database name>")

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import psqlwrapper
 
 if len(sys.argv) > 1:
     wrap = psqlwrapper.PsqlWrapper(sys.argv[1].encode("utf-8"),
-                                   lambda x : "Helpful message",
+                                   lambda x: "Helpful message",
                                    psqlparser.PsqlParser())
 else:
     print(f"{os.path.basename(sys.executable)} main.py <database name>")

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
+import os
 import sys
 
+import psqlparser
 import wrapper
 
-if len(sys.argv) > 1:
-    wrap = wrapper.Wrapper(sys.argv[1].encode("utf-8"))
+if len(sys.argv) > 1:    
+    wrap = wrapper.Wrapper(sys.argv[1].encode("utf-8"), lambda x : "Helpful message", psqlparser.PsqlParser)
 else:
-    print("python3 main.py <database name>")
+    print(f"{os.path.basename(sys.executable)} main.py <database name>")

--- a/psqlparser.py
+++ b/psqlparser.py
@@ -1,62 +1,107 @@
-from typing import TextIO
-from pyparsing import CaselessLiteral, Char, MatchFirst, OneOrMore, ParserElement, Word, \
+"""Parse psql output."""
+
+from typing import List, TextIO
+from pyparsing import CaselessLiteral, Char, Literal, MatchFirst, OneOrMore, \
+    ParseException, ParseResults, ParserElement, SkipTo, Word, \
     identbodychars
 from string import printable
+
+ParserElement.enablePackrat(None)  # memoization optimization
 
 
 class PsqlParser:
     """Parses psql output for syntactic analysis."""
 
     # class debug
-    debug: bool = True
+    debug: bool = False
     fout: TextIO
 
-    prompt_chars = identbodychars
-    stmt_end = ";"
-    # SQL statement body can contain all printable characters (incl. whitespace), but not ';'
-    stmt_chars = \
-        printable.translate(str.maketrans("", "", stmt_end))
-    
+    prompt_chars: str = identbodychars
+    control_codes: str = '\x1b' + '\x08'
+    stmt_end: str = ";"
+    # Naively, SQL statement body can contain all printable characters
+    # (incl. whitespace), apart from ';'
+    stmt_chars: str = \
+        printable.translate(str.maketrans("", "", stmt_end)) + control_codes
+
     # parser tokens:
     # superusers have =# prompt
     tok_prompt: ParserElement = \
-        Word(prompt_chars) + CaselessLiteral("=>") | CaselessLiteral("=#")
-    # one_of(["=>", "=#"])
-    tok_prompt_newline: ParserElement = \
+        Word(prompt_chars) + (CaselessLiteral("=>") | CaselessLiteral("=#"))
+    tok_prompt_linebreak: ParserElement = \
         CaselessLiteral("->") | CaselessLiteral("-#")
-    # one_of(["->", "-#"])    
-    tok_semicolon: ParserElement = \
+    tok_stmt_end: ParserElement = \
         Char(';')
 
     # parser combinations
     match_prompt: ParserElement = \
         MatchFirst([tok_prompt])
+    match_sql_stmt_start: ParserElement = \
+        CaselessLiteral("SELECT ")  # All interesting stmts are 'select'
     match_sql_stmt: ParserElement = \
         Word(stmt_chars)
-    match_stmt_end: ParserElement = \
-        Word(stmt_end)
+    match_sql_stmt_end: ParserElement = \
+        tok_stmt_end
+    match_error: ParserElement = \
+        Literal("ERROR:")
 
     # TODO: allow multiple statements
     parse_sql_stmt: ParserElement = \
-        match_prompt + match_sql_stmt + match_stmt_end
+        match_prompt + match_sql_stmt + match_sql_stmt_end
 
     def __init__(self):
         """Plain constructor for PsqlParser."""
         if self.debug:
             self.fout = open('psqlparser.log', 'w')
 
-    def parse_first_found_stmt(self, psql: str) -> str:
-        """Find first statement in psql output.
-    
-        Expected to be eventually deprecated.
-        """
-#        print(psql)
-        for res, start, end in self.parse_sql_stmt.scan_string(psql):
-            print(res)
-            print(start)
-            print(end)
-        return ""
+    def parse_for_new_prompt(self, psql: str) -> List[str]:
+        """Parse for an empty prompt, usually to detect when a query \
+        evaluation has ended.
 
-if __name__ == "__main__":
-    p = PsqlParser()
-    p.parse_first_found_stmt("pgdb=> SELECT * FROM orders;")
+        Returns an empty list if none found.
+        """
+        results: List[str] = []
+        prompt_res: ParseResults = None
+        try:
+            prompt_res = self.match_prompt.parse_string(psql)
+        except ParseException as e:
+            if self.debug:
+                print(e.explain())
+
+        if prompt_res:
+            results = prompt_res.as_list()
+        return results
+
+    def parse_first_found_stmt(self, psql: str) -> List[str]:
+        """Parse for the content between two prompts. Returns an empty \
+        list if there is no statement or there was an error.
+
+        Expected to be deprecated when detecting multiple statements is
+        implemented.
+        """
+        match_stmt: ParserElement = \
+            ... + self.match_sql_stmt_start + self.match_sql_stmt + \
+            self.match_sql_stmt_end
+        match_query_error: ParserElement = \
+            SkipTo(self.match_error)
+
+        results: List[str] = []
+        stmt_res: ParseResults = None
+        error_res: ParseResults = None
+        try:
+            stmt_res = match_stmt.parse_string(psql)
+        except ParseException as e:
+            if self.debug:
+                print(e.explain())
+        try:
+            error_res = match_query_error.parse_string(psql)
+        except ParseException as e:
+            if self.debug: 
+                print(e.explain())
+
+        if stmt_res:
+            stmt_res_list = stmt_res.as_list()
+            results = [stmt_res_list[1], stmt_res_list[2], stmt_res_list[3]]
+        if error_res:
+            results = []
+        return results

--- a/psqlparser.py
+++ b/psqlparser.py
@@ -1,0 +1,15 @@
+from typing import TextIO
+import pyparsing
+
+class PsqlParser:
+
+    debug: bool == True
+    fout: TextIO
+    
+    def __init__(self):
+        if self.debug:
+            self.fout = open('psqlparser.log', 'w')
+
+    
+
+    

--- a/psqlparser.py
+++ b/psqlparser.py
@@ -1,15 +1,42 @@
 from typing import TextIO
-import pyparsing
+from pyparsing import CaselessLiteral, Char, MatchFirst, OneOrMore, ParserElement
+
 
 class PsqlParser:
+    """Parses psql output for syntactic analysis."""
 
-    debug: bool == True
+    # class debug
+    debug: bool = True
     fout: TextIO
+
+    legalSqlStatementChars = \
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"
+    # tähti sun muuta vielä tähän; regex-sääntökö tämä on?
     
+    # parser tokens:
+    # superusers have =# prompt
+    tok_prompt: ParserElement = \
+        CaselessLiteral("=>") | CaselessLiteral("=#")
+    tok_prompt_newline: ParserElement = \
+        CaselessLiteral("->") | CaselessLiteral("-#")
+    tok_semicolon: ParserElement = \
+        Char(';')
+
+    # parser combinations
+    match_prompt: ParserElement = \
+        MatchFirst([tok_prompt])
+#    sql_stmt: ParserElement = \
+#        Word(srange("[a-zA-Z]"), srange("[a-zA-Z0-9\*\ ")
+#    sql_stmt = prompt_end + stmt_body + semicolon  # TODO: allow multiple statements
+
     def __init__(self):
+        """Plain constructor for PsqlParser."""
         if self.debug:
             self.fout = open('psqlparser.log', 'w')
 
-    
+    def parse_first_found_stmt(psql: str) -> str:
+        """Find first statement in psql output.
 
-    
+        Expected to be eventually deprecated.
+        """
+        return

--- a/psqlwrapper.py
+++ b/psqlwrapper.py
@@ -1,4 +1,7 @@
+"""Interface with psql and capture all input and output."""
+
 from typing import Callable, List, TextIO
+from functools import reduce
 import pexpect
 
 from psqlparser import PsqlParser
@@ -15,8 +18,10 @@ from psqlparser import PsqlParser
 
 
 class PsqlWrapper:
+    """Handles terminal interfacing with psql, using the parameter parser \
+    to pick up relevant SQL statements for the hook function."""
 
-    debug: bool = True
+    debug: bool = False
     fout: TextIO
 
     input_log: bytes = b''
@@ -25,11 +30,9 @@ class PsqlWrapper:
     analyze: Callable[str, str]
     parser: PsqlParser
 
-    def __init__(self, db_name_parameter: bytes, hook_f: Callable[str, str], parser: PsqlParser):
-        """
-        Start wrapper on selected database.
-        """
-
+    def __init__(self, db_name_parameter: bytes,
+                 hook_f: Callable[str, str], parser: PsqlParser):
+        """Start wrapper on selected database."""
         self.db_name = db_name_parameter
         self.analyze = hook_f
         self.parser = parser
@@ -45,18 +48,18 @@ class PsqlWrapper:
                    output_filter=self.ofilter)
 
     def ifilter(self, input: bytes) -> bytes:
+        """User input filter function for pexpect.interact: not used."""
         self.input_log = self.input_log + input
         return input
 
     def ofilter(self, output: bytes) -> bytes:
-        """
-        Forward output to check_and_act_on_repl_output() and flush output log if substitute output is returned and replace output with it accordingly.
-        """
-
+        """Forward output to check_and_act_on_repl_output() and flush \
+        output log if substitute output is returned and replace output \
+        with it accordingly."""
         new_output: bytes = self.check_and_act_on_repl_output(output,
                                                               self.output_log)
 
-        if new_output is not None:
+        if new_output != b'':
             self.output_log = b''
             if self.debug:
                 self.fout.write(str(new_output) + '\n')
@@ -69,53 +72,56 @@ class PsqlWrapper:
 
     def check_and_act_on_repl_output(self, latest_output: bytes,
                                      psql_log: bytes) -> bytes:
-        """
-        Detect if psql has run a statement and is asking for a new statement ("=> " prompt). Entering a statement will always lead to a new prompt, so now the output_log will be examined if an interesting statement was run, and if it was run successfully. If so, add a fitting message in before the new prompt.
-        psql_log is only needed for analysis. latest_output is what's being changed and returned in new form.
-        """
-        prompt: bytes = self.db_name + b'=> '
+        """Detect if psql has run a statement and is asking for \
+        a new statement ("=> " prompt).
 
-        # psql output for new prompt will (pending bug reports) look like this b'db_name=> '
-        there_is_new_prompt: bool = latest_output.endswith(prompt)
+        Entering a statement will always lead to a new prompt, so now \
+        the output_log will be examined if an interesting statement was run, \
+        and if it was run successfully. If so, add a fitting message in \
+        before the new prompt.
+        psql_log is only needed for analysis.
+        latest_output is what's being changed and returned in new form.
+        """
+        there_is_new_prompt: bool = len(self.parser.parse_for_new_prompt(
+            bytes.decode(latest_output))) > 0
 
         if there_is_new_prompt:
-            previous_prompt_ends_at: int = psql_log.rfind(prompt)
-            if previous_prompt_ends_at < 0:
-                # User has entered a new statement right on our previously modified prompt,
-                # so => was lost when flushing output log
-                previous_prompt_ends_at = -1
+            # BUG: control codes are not handled. #27
+            parsed_psql_stmt: List[str] = \
+                self.parser.parse_first_found_stmt(
+                    bytes.decode(psql_log + latest_output))
 
-            decoded_stmt_and_result: str = bytes.decode(
-                psql_log[previous_prompt_ends_at + 1:]) + bytes.decode(latest_output[:latest_output.find(prompt)])
+            if parsed_psql_stmt:
+                sql_stmt: str = reduce(lambda x, y: x + y, parsed_psql_stmt)
 
-            if self.debug:
-                self.fout.write(decoded_stmt_and_result)
+                if self.debug:
+                    self.fout.write(sql_stmt + '\n')
 
-            parsed_psql: List(str) = self.parser.parse_first_found_stmt(decoded_stmt_and_result)
+                helpful_message: str = \
+                    self.analyze(sql_stmt)
 
-            helpful_message: str = self.analyze(parsed_psql)
+                return self.replace_prompt(helpful_message,
+                                           latest_output)
 
-            return self.replace_prompt(helpful_message,
-                                       latest_output)
-
-        return None
+        return b''
 
     def replace_prompt(self, new_prompt_msg: str,
                        prompt: bytes):
-        """
-        Fit the new message in the right place, just on the previous line before new prompt
-        """
-
+        """Fit the new message in the right place, \
+        just on the previous line before new prompt."""
         newline_pos: int = prompt.rfind(b'\n')
+
         if newline_pos < 0:
-            # trivial case
-            return new_prompt_msg.encode("utf-8") + b'\r\n' + prompt  # b'\x1b[?2004hpgdb=> '
+            # trivial case. # b'\x1b[?2004hpgdb=> '
+            return new_prompt_msg.encode("utf-8") + b'\r\n' + prompt
         else:
-            # prompt is more complicated and has newlines in it: psql REPL has outputted a multiline chunk that may
+            # prompt is more complicated and has newlines in it:
+            # psql REPL has outputted a multiline chunk that may
             # a) start from previous prompt
             # b) amidst a return statement
 
             prompt_line_begins_at: int = prompt.rfind(b'\x1b')
 
             return prompt[:prompt_line_begins_at - 1] + \
-                new_prompt_msg.encode("utf-8") + b'\r\n' + prompt[prompt_line_begins_at:]
+                new_prompt_msg.encode("utf-8") + b'\r\n' + \
+                prompt[prompt_line_begins_at:]

--- a/psqlwrapper.py
+++ b/psqlwrapper.py
@@ -13,7 +13,8 @@ import psqlparser
 # >
 # =
 
-class Wrapper:
+
+class PsqlWrapper:
 
     debug: bool = True
     fout: TextIO


### PR DESCRIPTION
Completes #14. Changes were made with #5 in mind, but it could not be resolved with planned approach, so it has to be rethought according to #27. This current implementation only sends proper SQL statement to the hook function if it is written perfectly straight-out, without using backspace, tabs, arrows or similar.