### PR TITLE
Add tentative QEP parsing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	text=auto

--- a/qepparser.py
+++ b/qepparser.py
@@ -1,0 +1,147 @@
+from typing import Callable, Iterable, List, TypedDict
+import psycopg2
+from psycopg2.extensions import connection
+
+
+# TODO: break into variants discriminated by Node Type
+# right now, the interface isn't safe to use because it's not clear what fields
+# are available for each node type
+node = TypedDict("Plan", {
+    "Node Type": str,
+    "Parent Relationship": str,
+    "Startup Cost": float,
+    "Total Cost": float,
+    "Plan Rows": int,
+    "Plan Width": int,
+    "Actual Startup Time": float,
+    "Actual Total Time": float,
+    "Actual Rows": int,
+    "Actual Loops": int,
+    "Plans": List["node"],
+    "Index Cond": str,
+    "Filter": str,
+    "Relation Name": str,
+    "Alias": str,
+    "Scan Direction": str,
+    "Index Name": str,
+    "Triggers": list[str],
+    "Total Runtime": float,
+})
+
+qep = TypedDict("QEP", {
+    "Plan": node,
+    "Triggers": list[str],
+    "Planning Time": float,
+    "Execution Time": float,
+    "Total Runtime": float,
+})
+
+
+class QEPNode:
+    """A node in a query execution plan."""
+
+    def __init__(self, node_: node):
+        self._node = node_
+
+    def __iter__(self) -> Iterable["QEPNode"]:
+        """Iterate over child nodes."""
+        return map(QEPNode, self._node["Plans"])
+
+    def __len__(self) -> int:
+        """Get the number of child nodes."""
+        return len(self._node["Plans"])
+
+    def __getitem__(self, key: int) -> "QEPNode":
+        """Get the child node at the given index."""
+        return QEPNode(self._node["Plans"][key])
+
+    def __str__(self):
+        return self._node.__str__()
+
+    def __repr__(self):
+        return self._node.__repr__()
+
+    @property
+    def plan(self) -> node:
+        """A dict of the node's properties."""
+        return self._node
+
+    @property
+    def plans(self) -> list[node]:
+        """A list of the node's children."""
+        return self._node["Plans"]
+
+    def find(self, pred: Callable[[node], bool]) -> list[node]:
+        """Find nodes matching the predicate."""
+        return list(filter(pred, self._node["Plans"]))
+
+
+class QEPAnalysis:
+    """Represents the result of EXPLAIN ANALYZE."""
+
+    def __init__(self, qep_: qep):
+        self._qep = qep_
+
+    def __str__(self):
+        return self._qep.__str__()
+
+    def __repr__(self):
+        return self._qep.__repr__()
+
+    @property
+    def root(self) -> QEPNode:
+        """The root node of the query execution plan."""
+        return QEPNode(self._qep["Plan"])
+
+    @property
+    def plan(self) -> node:
+        """A dict of the root node's properties."""
+        return self._qep["Plan"]
+
+    @property
+    def qep(self) -> qep:
+        """A dict of the query execution plan's properties."""
+        return self._qep
+
+
+class QEPParser:
+    """Performs analyses on given queries, returning resultant QEPAnalysis."""
+
+    def __init__(self, *args, conn=None,  **kwargs):
+        self._ref = not not conn
+        self._conn: connection = conn or psycopg2.connect(*args, **kwargs)
+
+    def __del__(self):
+        if not self._ref:
+            self._conn.close()
+
+    def __call__(self, stmt: str, *args, **kwargs) -> QEPAnalysis:
+        """
+        Executes a query and returns the query execution plan as a dictionary.
+
+        Parameters:
+            stmt: The query to execute.
+            *args: Positional arguments to pass to cursor.execute().
+            **kwargs: Keyword arguments to pass to cursor.execute().
+
+        Returns:
+            A dictionary representing the query execution plan.
+        """
+        stmt = f"explain (format json, analyze, verbose) {stmt.strip().rstrip(';')};"
+        with self._conn.cursor() as cur:
+            cur.execute(stmt, *args, **kwargs)
+            res = cur.fetchall()
+            self._conn.rollback()
+            if (n := len(res)) != 1:
+                raise ValueError(f"Expected 1 row, got {n}")
+            if (n := len(res[0])) != 1:
+                raise ValueError(f"Expected 1 column, got {n}")
+            if (n := len(res[0][0])) != 1:
+                raise ValueError(f"Expected 1 item in column, got {n}")
+            if (t := type(res[0][0][0])) != dict:
+                raise ValueError(f"Expected dict in column, got {t}")
+            return QEPAnalysis(res[0][0][0])
+
+    def parse(self, stmt: str, *args, **kwargs) -> QEPAnalysis:
+        '''Alias for __call__'''
+        return self(stmt, *args, **kwargs)

--- a/test_qepparser.py
+++ b/test_qepparser.py
@@ -1,0 +1,124 @@
+import pytest
+import psycopg2
+
+from os import getenv
+from pytest_postgresql import factories
+from psycopg2.extensions import connection
+
+import qepparser
+
+
+def load_database(**kwargs):
+    conn: connection = psycopg2.connect(**kwargs)
+    with conn.cursor() as cur:
+        cur.execute("""
+        -- for copy-and-pasting
+        drop table if exists comments;
+        drop table if exists users;
+        drop table if exists stories;
+        
+        -- demonstrates relational data
+        create table stories (id serial primary key, name varchar);
+        create table users (id serial primary key, name varchar);
+        create table comments (
+            id serial primary key,
+            story_id integer references stories(id) on delete cascade,
+            user_id integer references users(id) on delete cascade,
+            comment varchar);
+            
+        -- populate with sample data
+        insert into stories (name) values ('story1');
+        insert into stories (name) values ('story2');
+        insert into users (name) values ('user1');
+        insert into users (name) values ('user2');
+        insert into comments (story_id, user_id, comment) values (1, 1, 'comment1');
+        insert into comments (story_id, user_id, comment) values (1, 2, 'comment2');
+        insert into comments (story_id, user_id, comment) values (2, 1, 'comment3');
+        insert into comments (story_id, user_id, comment) values (2, 2, 'comment4');
+        """)
+        conn.commit()
+
+
+postgresql_in_docker = factories.postgresql_noproc(
+    load=[load_database],
+    user=getenv("POSTGRES_USER", "postgres"),
+    password=getenv("POSTGRES_PASSWORD", "postgres"))
+postgresql = factories.postgresql("postgresql_in_docker")
+
+
+@pytest.fixture
+def parser(postgresql: connection):
+    return qepparser.QEPParser(conn=postgresql)
+
+
+def test_qep_structure(parser: qepparser.QEPParser):
+    """Test that the QEP structure is as expected."""
+
+    qep = parser("select * from stories")
+    assert qep.plan["Node Type"] == "Seq Scan"
+    assert qep.plan["Relation Name"] == "stories"
+    assert qep.plan["Alias"] == "stories"
+    assert qep.plan["Actual Rows"] == 2
+
+    qep = parser("select * from users")
+    assert qep.plan["Node Type"] == "Seq Scan"
+    assert qep.plan["Relation Name"] == "users"
+    assert qep.plan["Alias"] == "users"
+    assert qep.plan["Actual Rows"] == 2
+
+    qep = parser("select * from comments")
+    assert qep.plan["Node Type"] == "Seq Scan"
+    assert qep.plan["Relation Name"] == "comments"
+    assert qep.plan["Alias"] == "comments"
+    assert qep.plan["Actual Rows"] == 4
+
+    qep = parser("select * from stories where id = 1")
+    assert qep.plan["Node Type"] == "Index Scan"
+    assert qep.plan["Relation Name"] == "stories"
+    assert qep.plan["Alias"] == "stories"
+    assert qep.plan["Actual Rows"] == 1
+
+    qep = parser("select * from users where id = 1")
+    assert qep.plan["Node Type"] == "Index Scan"
+    assert qep.plan["Relation Name"] == "users"
+    assert qep.plan["Alias"] == "users"
+    assert qep.plan["Actual Rows"] == 1
+
+    qep = parser("select * from comments where id = 1")
+    assert qep.plan["Node Type"] == "Index Scan"
+    assert qep.plan["Relation Name"] == "comments"
+    assert qep.plan["Alias"] == "comments"
+    assert qep.plan["Actual Rows"] == 1
+
+    qep = parser("select * from stories where id = 1 and id = 2")
+    assert qep.plan["Node Type"] == "Result"
+    assert qep.root[0].plan["Node Type"] == "Index Scan"
+    assert qep.root[0].plan["Relation Name"] == "stories"
+    assert qep.root[0].plan["Alias"] == "stories"
+    assert qep.root[0].plan["Actual Rows"] == 0
+
+    qep = parser("select * from users where id = 1 and id = 2")
+    assert qep.plan["Node Type"] == "Result"
+    assert qep.root[0].plan["Node Type"] == "Index Scan"
+    assert qep.root[0].plan["Relation Name"] == "users"
+    assert qep.root[0].plan["Alias"] == "users"
+    assert qep.root[0].plan["Actual Rows"] == 0
+
+    qep = parser("select * from comments where id = 1 and id = 2")
+    assert qep.plan["Node Type"] == "Result"
+    assert qep.root[0].plan["Node Type"] == "Index Scan"
+    assert qep.root[0].plan["Relation Name"] == "comments"
+    assert qep.root[0].plan["Alias"] == "comments"
+    assert qep.root[0].plan["Actual Rows"] == 0
+
+    qep = parser("select * from stories where id = 1 or id = 2")
+    assert qep.plan["Node Type"] == "Bitmap Heap Scan"
+    assert qep.plan["Relation Name"] == "stories"
+    assert qep.plan["Alias"] == "stories"
+    assert qep.plan["Actual Rows"] == 2
+
+    qep = parser("select * from users where id = 1 or id = 2")
+    assert qep.plan["Node Type"] == "Bitmap Heap Scan"
+    assert qep.plan["Relation Name"] == "users"
+    assert qep.plan["Alias"] == "users"
+    assert qep.plan["Actual Rows"] == 2


### PR DESCRIPTION
Closes #10, closes #22 

Uses `psycopg2` for interfacing with postgres.
Uses `pytest_postgresql` for setting up a temporary, dockerized postgres DB for testing.
Passes data retrieved from postgres' `EXPLAIN ANALYZE` as-is, with some wrappers.